### PR TITLE
feat: support static import

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const code = generateRoutes({
 console.log(code)
 ```
 
-vue-route-generator will generate the following code (beautified the indentations etc.):
+vue-route-generator will generate like the following code (beautified the indentations etc.):
 
 ```js
 export default [
@@ -91,6 +91,7 @@ The routing is inspired by [Nuxt routing](https://nuxtjs.org/guide/routing) and 
 
 * `pages`: Path to the directory that contains your page components.
 * `importPrefix`: A string that will be added to importing component path (default `@/pages/`).
+* `dynamicImport`: Use dynamic import expression (`import()`) to import component (default `true`).
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,13 @@ import { resolveRoutePaths } from './resolve'
 export interface GenerateConfig {
   pages: string
   importPrefix?: string
+  dynamicImport?: boolean
 }
 
 export function generateRoutes({
   pages,
-  importPrefix = '@/pages/'
+  importPrefix = '@/pages/',
+  dynamicImport = true
 }: GenerateConfig): string {
   const pagePaths = fg.sync<string>('**/*.vue', {
     cwd: pages,
@@ -18,5 +20,5 @@ export function generateRoutes({
 
   const metaList = resolveRoutePaths(pagePaths, importPrefix)
 
-  return createRoutes(metaList)
+  return createRoutes(metaList, dynamicImport)
 }

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -2,6 +2,7 @@ import { NestedMap, setToMap } from './nested-map'
 
 export interface PageMeta {
   name: string
+  specifier: string
   path: string
   component: string
   children?: PageMeta[]
@@ -30,6 +31,7 @@ function pathMapToMeta(
     const path = map.value
     const meta: PageMeta = {
       name: pathToName(path),
+      specifier: pathToSpecifier(path),
       path: pathToRoute(path, parentDepth),
       component: importPrefix + path.join('/')
     }
@@ -82,6 +84,17 @@ function pathToName(segments: string[]): string {
       return s[0] === '_' ? s.slice(1) : s
     })
     .join('-')
+}
+
+function pathToSpecifier(segments: string[]): string {
+  const name = pathToName(segments)
+  const replaced = name
+    .replace(/(^|[^a-zA-Z])([a-zA-Z])/g, (_, a, b) => {
+      return a + b.toUpperCase()
+    })
+    .replace(/[^a-zA-Z0-9]/g, '')
+
+  return /^\d/.test(replaced) ? '_' + replaced : replaced
 }
 
 function pathToRoute(segments: string[], parentDepth: number): string {

--- a/src/template/routes.ts
+++ b/src/template/routes.ts
@@ -12,13 +12,24 @@ function createRoute(meta: PageMeta): string {
   {
     name: '${meta.name}',
     path: '${meta.path}',
-    component: () => import(/* webpackChunkName: "${meta.name}" */ '${
-    meta.component
-  }')${children}
+    component: ${meta.specifier}${children}
   }`
 }
 
-export function createRoutes(meta: PageMeta[]): string {
+function createImport(meta: PageMeta, dynamic: boolean): string {
+  const code = dynamic
+  ? `const ${meta.specifier} = () => import(/* webpackChunkName: "${meta.name}" */ '${
+    meta.component
+  }')`
+  : `import ${meta.specifier} from '${meta.component}'`
+
+  return meta.children
+    ? [code].concat(meta.children.map(child => createImport(child, dynamic))).join('\n')
+    : code
+}
+
+export function createRoutes(meta: PageMeta[], dynamic: boolean): string {
+  const imports = meta.map(m => createImport(m, dynamic)).join('\n')
   const code = meta.map(createRoute).join(',')
-  return `export default [${code}]`
+  return `${imports}\n\nexport default [${code}]`
 }

--- a/src/template/routes.ts
+++ b/src/template/routes.ts
@@ -18,13 +18,15 @@ function createRoute(meta: PageMeta): string {
 
 function createImport(meta: PageMeta, dynamic: boolean): string {
   const code = dynamic
-  ? `const ${meta.specifier} = () => import(/* webpackChunkName: "${meta.name}" */ '${
-    meta.component
-  }')`
-  : `import ${meta.specifier} from '${meta.component}'`
+    ? `const ${meta.specifier} = () => import(/* webpackChunkName: "${
+        meta.name
+      }" */ '${meta.component}')`
+    : `import ${meta.specifier} from '${meta.component}'`
 
   return meta.children
-    ? [code].concat(meta.children.map(child => createImport(child, dynamic))).join('\n')
+    ? [code]
+        .concat(meta.children.map(child => createImport(child, dynamic)))
+        .join('\n')
     : code
 }
 

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -10,21 +10,25 @@ Array [
             "component": "@/pages/users/_id/foo.vue",
             "name": "users-id-foo",
             "path": "foo",
+            "specifier": "UsersIdFoo",
           },
         ],
         "component": "@/pages/users/_id.vue",
         "name": "users-id",
         "path": ":id",
+        "specifier": "UsersId",
       },
       Object {
         "component": "@/pages/users/test.vue",
         "name": "users-test",
         "path": "test",
+        "specifier": "UsersTest",
       },
     ],
     "component": "@/pages/users.vue",
     "name": "users",
     "path": "/users",
+    "specifier": "Users",
   },
 ]
 `;
@@ -35,6 +39,7 @@ Array [
     "component": "@/pages/users/_id.vue",
     "name": "users-id",
     "path": "/users/:id",
+    "specifier": "UsersId",
   },
 ]
 `;
@@ -47,16 +52,38 @@ Array [
         "component": "@/pages/foo/index.vue",
         "name": "foo-index",
         "path": "",
+        "specifier": "FooIndex",
       },
       Object {
         "component": "@/pages/foo/bar.vue",
         "name": "foo-bar",
         "path": "bar",
+        "specifier": "FooBar",
       },
     ],
     "component": "@/pages/foo.vue",
     "name": "foo",
     "path": "/foo",
+    "specifier": "Foo",
+  },
+]
+`;
+
+exports[`Route resolution resolves number prefixed route 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "component": "@/pages/1test/2nested.vue",
+        "name": "1test-2nested",
+        "path": "2nested",
+        "specifier": "_1Test2Nested",
+      },
+    ],
+    "component": "@/pages/1test.vue",
+    "name": "1test",
+    "path": "/1test",
+    "specifier": "_1Test",
   },
 ]
 `;
@@ -67,16 +94,19 @@ Array [
     "component": "@/pages/index.vue",
     "name": "index",
     "path": "/",
+    "specifier": "Index",
   },
   Object {
     "component": "@/pages/foo.vue",
     "name": "foo",
     "path": "/foo",
+    "specifier": "Foo",
   },
   Object {
     "component": "@/pages/baz.vue",
     "name": "baz",
     "path": "/baz",
+    "specifier": "Baz",
   },
 ]
 `;
@@ -89,11 +119,13 @@ Array [
         "component": "@/pages/users/session/login.vue",
         "name": "users-session-login",
         "path": "session/login",
+        "specifier": "UsersSessionLogin",
       },
     ],
     "component": "@/pages/users.vue",
     "name": "users",
     "path": "/users",
+    "specifier": "Users",
   },
 ]
 `;

--- a/test/__snapshots__/route-template.spec.ts.snap
+++ b/test/__snapshots__/route-template.spec.ts.snap
@@ -1,35 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Route template should generate nested routes 1`] = `
-"export default [
+"const Foo = () => import(/* webpackChunkName: \\"foo\\" */ '@/pages/foo.vue')
+const FooBar = () => import(/* webpackChunkName: \\"bar\\" */ '@/pages/bar.vue')
+const FooBaz = () => import(/* webpackChunkName: \\"baz\\" */ '@/pages/baz.vue')
+
+export default [
   {
     name: 'foo',
     path: '/foo',
-    component: () => import(/* webpackChunkName: \\"foo\\" */ '@/pages/foo.vue'),
+    component: Foo,
     children: [
   {
     name: 'bar',
     path: 'bar',
-    component: () => import(/* webpackChunkName: \\"bar\\" */ '@/pages/bar.vue')
+    component: FooBar
   },
   {
     name: 'baz',
     path: 'baz',
-    component: () => import(/* webpackChunkName: \\"baz\\" */ '@/pages/baz.vue')
+    component: FooBaz
   }]
   }]"
 `;
 
 exports[`Route template should generate routes 1`] = `
-"export default [
+"const Foo = () => import(/* webpackChunkName: \\"foo\\" */ '@/pages/foo.vue')
+const Bar = () => import(/* webpackChunkName: \\"bar\\" */ '@/pages/bar.vue')
+
+export default [
   {
     name: 'foo',
     path: '/foo',
-    component: () => import(/* webpackChunkName: \\"foo\\" */ '@/pages/foo.vue')
+    component: Foo
   },
   {
     name: 'bar',
     path: '/bar',
-    component: () => import(/* webpackChunkName: \\"bar\\" */ '@/pages/bar.vue')
+    component: Bar
+  }]"
+`;
+
+exports[`Route template should generate static import code 1`] = `
+"import Foo from '@/pages/foo.vue'
+import Bar from '@/pages/bar.vue'
+
+export default [
+  {
+    name: 'foo',
+    path: '/foo',
+    component: Foo
+  },
+  {
+    name: 'bar',
+    path: '/bar',
+    component: Bar
   }]"
 `;

--- a/test/resolve.spec.ts
+++ b/test/resolve.spec.ts
@@ -21,4 +21,6 @@ describe('Route resolution', () => {
   ])
 
   test('resolves spase nested routes', ['users.vue', 'users/session/login.vue'])
+
+  test('resolves number prefixed route', ['1test.vue', '1test/2nested.vue'])
 })

--- a/test/route-template.spec.ts
+++ b/test/route-template.spec.ts
@@ -6,33 +6,38 @@ describe('Route template', () => {
     const meta: PageMeta[] = [
       {
         name: 'foo',
+        specifier: 'Foo',
         path: '/foo',
         component: '@/pages/foo.vue'
       },
       {
         name: 'bar',
+        specifier: 'Bar',
         path: '/bar',
         component: '@/pages/bar.vue'
       }
     ]
 
-    expect(createRoutes(meta)).toMatchSnapshot()
+    expect(createRoutes(meta, true)).toMatchSnapshot()
   })
 
   it('should generate nested routes', () => {
     const meta: PageMeta[] = [
       {
         name: 'foo',
+        specifier: 'Foo',
         path: '/foo',
         component: '@/pages/foo.vue',
         children: [
           {
             name: 'bar',
+            specifier: 'FooBar',
             path: 'bar',
             component: '@/pages/bar.vue'
           },
           {
             name: 'baz',
+            specifier: 'FooBaz',
             path: 'baz',
             component: '@/pages/baz.vue'
           }
@@ -40,6 +45,25 @@ describe('Route template', () => {
       }
     ]
 
-    expect(createRoutes(meta)).toMatchSnapshot()
+    expect(createRoutes(meta, true)).toMatchSnapshot()
+  })
+
+  it('should generate static import code', () => {
+    const meta: PageMeta[] = [
+      {
+        name: 'foo',
+        specifier: 'Foo',
+        path: '/foo',
+        component: '@/pages/foo.vue'
+      },
+      {
+        name: 'bar',
+        specifier: 'Bar',
+        path: '/bar',
+        component: '@/pages/bar.vue'
+      }
+    ]
+
+    expect(createRoutes(meta, false)).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
fix https://github.com/ktsn/vue-auto-routing/issues/1

It will be generate the routes with static import for components by specifying `dynamicImport: false` option. 

It is useful when the users do not want to split the output code.

```js
const code = generateRoutes({
  pages: './pages',
  dynamicImport: false
})

console.log(code)
```

This generates:

```js
import Index from '@/pages/index.vue'
import Users from '@/pages/users.vue'
import UsersId from '@/pages/users/_id.vue'

export default [
  {
    name: 'index',
    path: '/',
    component: Index
  },
  {
    name: 'users',
    path: '/users',
    component: Users,
    children: [
      {
        name: 'users-id',
        path: ':id',
        component: UsersId
      }
    ]
  }
]
```