### PR TITLE
feat: allow to specify route meta in custom block

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,39 @@ export default new Router({
 
 The routing is inspired by [Nuxt routing](https://nuxtjs.org/guide/routing) and is implemented with the same functionality.
 
+## Route Meta
+
+If the components have `<route-meta>` custom block, its json content is passed to generated route meta.
+
+For example, if `index.vue` has the following `<route-meta>` block:
+
+```vue
+<route-meta>
+{
+  "title": "Hello"
+}
+</route-meta>
+
+<template>
+  <h1>Hello</h1>
+</template>
+```
+
+The generated route config is like following:
+
+```js
+module.exports = [
+  {
+    name: 'index',
+    path: '/',
+    component: () => import('@/pages/index.vue'),
+    meta: {
+      title: 'Hello'
+    }
+  }
+]
+```
+
 ## References
 
 ### `generateRoutes(config: GenerateConfig): string`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,6 +1083,12 @@
         "whatwg-url": "^6.4.0"
       }
     },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2455,6 +2461,12 @@
           }
         }
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -5670,6 +5682,22 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vue": {
+      "version": "2.5.16",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.16.tgz",
+      "integrity": "sha512-/ffmsiVuPC8PsWcFkZngdpas19ABm5mh2wA7iDqcltyCTwlgZjHGeJYOXkBMo422iPwIcviOtrTCUpSfXmToLQ==",
+      "dev": true
+    },
+    "vue-template-compiler": {
+      "version": "2.5.16",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.16.tgz",
+      "integrity": "sha512-ZbuhCcF/hTYmldoUOVcu2fcbeSAZnfzwDskGduOrnjBiIWHgELAd+R8nAtX80aZkceWDKGQ6N9/0/EUpt+l22A==",
+      "dev": true,
+      "requires": {
+        "de-indent": "^1.0.2",
+        "he": "^1.1.0"
       }
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -56,9 +56,14 @@
     "tslint": "^5.9.1",
     "tslint-config-ktsn": "^2.1.0",
     "tslint-config-prettier": "^1.10.0",
-    "typescript": "^2.8.1"
+    "typescript": "^2.8.1",
+    "vue": "^2.5.16",
+    "vue-template-compiler": "^2.5.16"
   },
   "dependencies": {
     "fast-glob": "^2.2.2"
+  },
+  "peerDependencies": {
+    "vue-template-compiler": "^2.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs'
 import * as fg from 'fast-glob'
 import { createRoutes } from './template/routes'
 import { resolveRoutePaths } from './resolve'
@@ -18,7 +19,11 @@ export function generateRoutes({
     onlyFiles: true
   })
 
-  const metaList = resolveRoutePaths(pagePaths, importPrefix)
+  const metaList = resolveRoutePaths(pagePaths, importPrefix, readFile)
 
   return createRoutes(metaList, dynamicImport)
+}
+
+function readFile(path: string): string {
+  return fs.readFileSync(path, 'utf8')
 }

--- a/src/template/routes.ts
+++ b/src/template/routes.ts
@@ -8,11 +8,15 @@ function createChildrenRoute(children: PageMeta[]): string {
 function createRoute(meta: PageMeta): string {
   const children = !meta.children ? '' : createChildrenRoute(meta.children)
 
+  const routeMeta = !meta.routeMeta
+    ? ''
+    : ',\nmeta: ' + JSON.stringify(meta.routeMeta, null, 2)
+
   return `
   {
     name: '${meta.name}',
     path: '${meta.path}',
-    component: ${meta.specifier}${children}
+    component: ${meta.specifier}${routeMeta}${children}
   }`
 }
 

--- a/src/vue-template-compiler.d.ts
+++ b/src/vue-template-compiler.d.ts
@@ -1,0 +1,190 @@
+declare module 'vue-template-compiler' {
+  import Vue, { VNode } from 'vue'
+  /*
+ * Template compilation options / results
+ */
+  interface CompilerOptions {
+    modules?: ModuleOptions[]
+    directives?: Record<string, DirectiveFunction>
+    preserveWhitespace?: boolean
+  }
+  interface CompiledResult {
+    ast: ASTElement | undefined
+    render: string
+    staticRenderFns: string[]
+    errors: string[]
+    tips: string[]
+  }
+  interface CompiledResultFunctions {
+    render: () => VNode
+    staticRenderFns: (() => VNode)[]
+  }
+  interface ModuleOptions {
+    preTransformNode: (el: ASTElement) => ASTElement | undefined
+    transformNode: (el: ASTElement) => ASTElement | undefined
+    postTransformNode: (el: ASTElement) => void
+    genData: (el: ASTElement) => string
+    transformCode?: (el: ASTElement, code: string) => string
+    staticKeys?: string[]
+  }
+  type DirectiveFunction = (
+    node: ASTElement,
+    directiveMeta: ASTDirective
+  ) => void
+  /*
+ * AST Types
+ */
+  /**
+   * - 0: FALSE - whole sub tree un-optimizable
+   * - 1: FULL - whole sub tree optimizable
+   * - 2: SELF - self optimizable but has some un-optimizable children
+   * - 3: CHILDREN - self un-optimizable but have fully optimizable children
+   * - 4: PARTIAL - self un-optimizable with some un-optimizable children
+   */
+  export type SSROptimizability = 0 | 1 | 2 | 3 | 4
+  export interface ASTModifiers {
+    [key: string]: boolean
+  }
+  export interface ASTIfCondition {
+    exp: string | undefined
+    block: ASTElement
+  }
+  export interface ASTElementHandler {
+    value: string
+    params?: any[]
+    modifiers: ASTModifiers | undefined
+  }
+  export interface ASTElementHandlers {
+    [key: string]: ASTElementHandler | ASTElementHandler[]
+  }
+  export interface ASTDirective {
+    name: string
+    rawName: string
+    value: string
+    arg: string | undefined
+    modifiers: ASTModifiers | undefined
+  }
+  export type ASTNode = ASTElement | ASTText | ASTExpression
+  export interface ASTElement {
+    type: 1
+    tag: string
+    attrsList: { name: string; value: any }[]
+    attrsMap: Record<string, any>
+    parent: ASTElement | undefined
+    children: ASTNode[]
+    processed?: true
+    static?: boolean
+    staticRoot?: boolean
+    staticInFor?: boolean
+    staticProcessed?: boolean
+    hasBindings?: boolean
+    text?: string
+    attrs?: { name: string; value: any }[]
+    props?: { name: string; value: string }[]
+    plain?: boolean
+    pre?: true
+    ns?: string
+    component?: string
+    inlineTemplate?: true
+    transitionMode?: string | null
+    slotName?: string
+    slotTarget?: string
+    slotScope?: string
+    scopedSlots?: Record<string, ASTElement>
+    ref?: string
+    refInFor?: boolean
+    if?: string
+    ifProcessed?: boolean
+    elseif?: string
+    else?: true
+    ifConditions?: ASTIfCondition[]
+    for?: string
+    forProcessed?: boolean
+    key?: string
+    alias?: string
+    iterator1?: string
+    iterator2?: string
+    staticClass?: string
+    classBinding?: string
+    staticStyle?: string
+    styleBinding?: string
+    events?: ASTElementHandlers
+    nativeEvents?: ASTElementHandlers
+    transition?: string | true
+    transitionOnAppear?: boolean
+    model?: {
+      value: string
+      callback: string
+      expression: string
+    }
+    directives?: ASTDirective[]
+    forbidden?: true
+    once?: true
+    onceProcessed?: boolean
+    wrapData?: (code: string) => string
+    wrapListeners?: (code: string) => string
+    // 2.4 ssr optimization
+    ssrOptimizability?: SSROptimizability
+    // weex specific
+    appendAsTree?: boolean
+  }
+  export interface ASTExpression {
+    type: 2
+    expression: string
+    text: string
+    tokens: (string | Record<string, any>)[]
+    static?: boolean
+    // 2.4 ssr optimization
+    ssrOptimizability?: SSROptimizability
+  }
+  export interface ASTText {
+    type: 3
+    text: string
+    static?: boolean
+    isComment?: boolean
+    // 2.4 ssr optimization
+    ssrOptimizability?: SSROptimizability
+  }
+  /*
+ * SFC parser related types
+ */
+  interface SFCParserOptions {
+    pad?: true | 'line' | 'space'
+  }
+  export interface SFCBlock {
+    type: string
+    content: string
+    attrs: Record<string, string>
+    start?: number
+    end?: number
+    lang?: string
+    src?: string
+    scoped?: boolean
+    module?: string | boolean
+  }
+  export interface SFCDescriptor {
+    template: SFCBlock | undefined
+    script: SFCBlock | undefined
+    styles: SFCBlock[]
+    customBlocks: SFCBlock[]
+  }
+  /*
+ * Exposed functions
+ */
+  export function compile(
+    template: string,
+    options?: CompilerOptions
+  ): CompiledResult
+  export function compileToFunctions(template: string): CompiledResultFunctions
+  export function ssrCompile(
+    template: string,
+    options?: CompilerOptions
+  ): CompiledResult
+  export function ssrCompileToFunctions(
+    template: string
+  ): CompiledResultFunctions
+  export function parseComponent(
+    file: string,
+    options?: SFCParserOptions
+  ): SFCDescriptor
+}

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Route resolution resolve route meta 1`] = `
+Array [
+  Object {
+    "component": "@/pages/meta.vue",
+    "name": "meta",
+    "path": "/meta",
+    "routeMeta": Object {
+      "title": "Hello",
+    },
+    "specifier": "Meta",
+  },
+]
+`;
+
 exports[`Route resolution resolves dynamic nested routes 1`] = `
 Array [
   Object {

--- a/test/__snapshots__/route-template.spec.ts.snap
+++ b/test/__snapshots__/route-template.spec.ts.snap
@@ -24,6 +24,20 @@ export default [
   }]"
 `;
 
+exports[`Route template should generate route meta 1`] = `
+"import Foo from '@/pages/foo.vue'
+
+export default [
+  {
+    name: 'foo',
+    path: '/foo',
+    component: Foo,
+meta: {
+  \\"title\\": \\"Hello\\"
+}
+  }]"
+`;
+
 exports[`Route template should generate routes 1`] = `
 "const Foo = () => import(/* webpackChunkName: \\"foo\\" */ '@/pages/foo.vue')
 const Bar = () => import(/* webpackChunkName: \\"bar\\" */ '@/pages/bar.vue')

--- a/test/resolve.spec.ts
+++ b/test/resolve.spec.ts
@@ -1,9 +1,31 @@
 import { resolveRoutePaths } from '../src/resolve'
 
+function mockReadFile(path: string): string {
+  if (path === 'meta.vue') {
+    return `<route-meta>
+    {
+      "title": "Hello"
+    }
+    </route-meta>`
+  }
+
+  if (path === 'invalid-meta.vue') {
+    return `<route-meta>
+    {
+      "invalid": "Test",
+    }
+    </route-meta>`
+  }
+
+  return ''
+}
+
 describe('Route resolution', () => {
   function test(name: string, paths: string[]): void {
     it(name, () => {
-      expect(resolveRoutePaths(paths, '@/pages/')).toMatchSnapshot()
+      expect(
+        resolveRoutePaths(paths, '@/pages/', mockReadFile)
+      ).toMatchSnapshot()
     })
   }
 
@@ -23,4 +45,14 @@ describe('Route resolution', () => {
   test('resolves spase nested routes', ['users.vue', 'users/session/login.vue'])
 
   test('resolves number prefixed route', ['1test.vue', '1test/2nested.vue'])
+
+  test('resolve route meta', ['meta.vue'])
+
+  it('throws error when failed to parse route-meta', () => {
+    expect(() => {
+      resolveRoutePaths(['invalid-meta.vue'], '@/pages/', mockReadFile)
+    }).toThrow(
+      /Invalid json format of <route-meta> content in invalid-meta\.vue/
+    )
+  })
 })

--- a/test/route-template.spec.ts
+++ b/test/route-template.spec.ts
@@ -66,4 +66,20 @@ describe('Route template', () => {
 
     expect(createRoutes(meta, false)).toMatchSnapshot()
   })
+
+  it('should generate route meta', () => {
+    const meta: PageMeta[] = [
+      {
+        name: 'foo',
+        specifier: 'Foo',
+        path: '/foo',
+        component: '@/pages/foo.vue',
+        routeMeta: {
+          title: 'Hello'
+        }
+      }
+    ]
+
+    expect(createRoutes(meta, false)).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
fix #1 

This PR let the users to specify [route meta](https://router.vuejs.org/guide/advanced/meta.html) via `<route-meta>` custom field. The json content will be just passed to `meta` option of route record.