### PR TITLE
fix: Sort non-variable routes before variable ones, to prioritize them.

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -83,9 +83,22 @@ function pathMapChildrenToMeta(
   readFile: (path: string) => string,
   parentDepth: number
 ): PageMeta[] {
-  return Array.from(children.values()).reduce<PageMeta[]>((acc, value) => {
-    return acc.concat(pathMapToMeta(value, importPrefix, readFile, parentDepth))
-  }, [])
+  return Array.from(children.values())
+    .reduce<PageMeta[]>((acc, value) => {
+      return acc.concat(
+        pathMapToMeta(value, importPrefix, readFile, parentDepth)
+      )
+    }, [])
+    .sort(
+      (a, b) =>
+        isPathVariable(a.path)
+          ? isPathVariable(b.path) ? 0 : 1
+          : isPathVariable(b.path) ? -1 : 0
+    )
+}
+
+function isPathVariable(path: string): boolean {
+  return path[0] === ':'
 }
 
 function isDynamicRoute(segment: string): boolean {

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -77,6 +77,17 @@ function pathMapToMeta(
     : []
 }
 
+function sortPathsFixedBeforeDynamic(a: string, b: string) {
+  const aIsVariable = isPathVariable(a)
+  const bIsVariable = isPathVariable(b)
+
+  if (aIsVariable) {
+    return bIsVariable ? 0 : 1
+  }
+
+  return bIsVariable ? -1 : 0
+}
+
 function pathMapChildrenToMeta(
   children: Map<string, NestedMap<string[]>>,
   importPrefix: string,
@@ -89,12 +100,7 @@ function pathMapChildrenToMeta(
         pathMapToMeta(value, importPrefix, readFile, parentDepth)
       )
     }, [])
-    .sort(
-      (a, b) =>
-        isPathVariable(a.path)
-          ? isPathVariable(b.path) ? 0 : 1
-          : isPathVariable(b.path) ? -1 : 0
-    )
+    .sort((a, b) => sortPathsFixedBeforeDynamic(a.path, b.path))
 }
 
 function isPathVariable(path: string): boolean {

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -19,6 +19,12 @@ Array [
   Object {
     "children": Array [
       Object {
+        "component": "@/pages/users/test.vue",
+        "name": "users-test",
+        "path": "test",
+        "specifier": "UsersTest",
+      },
+      Object {
         "children": Array [
           Object {
             "component": "@/pages/users/_id/foo.vue",
@@ -31,12 +37,6 @@ Array [
         "name": "users-id",
         "path": ":id",
         "specifier": "UsersId",
-      },
-      Object {
-        "component": "@/pages/users/test.vue",
-        "name": "users-test",
-        "path": "test",
-        "specifier": "UsersTest",
       },
     ],
     "component": "@/pages/users.vue",


### PR DESCRIPTION
* Now matches `foo/new.vue` before `foo/_id.vue` consistently.