### PR TITLE
fix: prioritize static routes than dynamic routes

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -83,9 +83,22 @@ function pathMapChildrenToMeta(
   readFile: (path: string) => string,
   parentDepth: number
 ): PageMeta[] {
-  return Array.from(children.values()).reduce<PageMeta[]>((acc, value) => {
-    return acc.concat(pathMapToMeta(value, importPrefix, readFile, parentDepth))
-  }, [])
+  return Array.from(children.values())
+    .reduce<PageMeta[]>((acc, value) => {
+      return acc.concat(
+        pathMapToMeta(value, importPrefix, readFile, parentDepth)
+      )
+    }, [])
+    .sort(
+      (a, b) =>
+        isPathVariable(a.path)
+          ? isPathVariable(b.path) ? 0 : 1
+          : isPathVariable(b.path) ? -1 : 0
+    )
+}
+
+function isPathVariable(path: string): boolean {
+  return path[0] === ':'
 }
 
 function isDynamicRoute(segment: string): boolean {

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -77,6 +77,17 @@ function pathMapToMeta(
     : []
 }
 
+function sortPathsFixedBeforeDynamic(a: string, b: string) {
+  const aIsVariable = isPathVariable(a)
+  const bIsVariable = isPathVariable(b)
+
+  if (aIsVariable) {
+    return bIsVariable ? 0 : 1
+  }
+
+  return bIsVariable ? -1 : 0
+}
+
 function pathMapChildrenToMeta(
   children: Map<string, NestedMap<string[]>>,
   importPrefix: string,
@@ -89,12 +100,7 @@ function pathMapChildrenToMeta(
         pathMapToMeta(value, importPrefix, readFile, parentDepth)
       )
     }, [])
-    .sort(
-      (a, b) =>
-        isPathVariable(a.path)
-          ? isPathVariable(b.path) ? 0 : 1
-          : isPathVariable(b.path) ? -1 : 0
-    )
+    .sort((a, b) => sortPathsFixedBeforeDynamic(a.path, b.path))
 }
 
 function isPathVariable(path: string): boolean {

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -6,6 +6,9 @@ Array [
     "component": "@/pages/meta.vue",
     "name": "meta",
     "path": "/meta",
+    "pathSegments": Array [
+      "meta",
+    ],
     "routeMeta": Object {
       "title": "Hello",
     },
@@ -22,6 +25,10 @@ Array [
         "component": "@/pages/users/test.vue",
         "name": "users-test",
         "path": "test",
+        "pathSegments": Array [
+          "users",
+          "test",
+        ],
         "specifier": "UsersTest",
       },
       Object {
@@ -30,18 +37,30 @@ Array [
             "component": "@/pages/users/_id/foo.vue",
             "name": "users-id-foo",
             "path": "foo",
+            "pathSegments": Array [
+              "users",
+              ":id",
+              "foo",
+            ],
             "specifier": "UsersIdFoo",
           },
         ],
         "component": "@/pages/users/_id.vue",
         "name": "users-id",
         "path": ":id",
+        "pathSegments": Array [
+          "users",
+          ":id",
+        ],
         "specifier": "UsersId",
       },
     ],
     "component": "@/pages/users.vue",
     "name": "users",
     "path": "/users",
+    "pathSegments": Array [
+      "users",
+    ],
     "specifier": "Users",
   },
 ]
@@ -53,6 +72,10 @@ Array [
     "component": "@/pages/users/_id.vue",
     "name": "users-id",
     "path": "/users/:id",
+    "pathSegments": Array [
+      "users",
+      ":id",
+    ],
     "specifier": "UsersId",
   },
 ]
@@ -66,18 +89,28 @@ Array [
         "component": "@/pages/foo/index.vue",
         "name": "foo-index",
         "path": "",
+        "pathSegments": Array [
+          "foo",
+        ],
         "specifier": "FooIndex",
       },
       Object {
         "component": "@/pages/foo/bar.vue",
         "name": "foo-bar",
         "path": "bar",
+        "pathSegments": Array [
+          "foo",
+          "bar",
+        ],
         "specifier": "FooBar",
       },
     ],
     "component": "@/pages/foo.vue",
     "name": "foo",
     "path": "/foo",
+    "pathSegments": Array [
+      "foo",
+    ],
     "specifier": "Foo",
   },
 ]
@@ -91,12 +124,19 @@ Array [
         "component": "@/pages/1test/2nested.vue",
         "name": "1test-2nested",
         "path": "2nested",
+        "pathSegments": Array [
+          "1test",
+          "2nested",
+        ],
         "specifier": "_1Test2Nested",
       },
     ],
     "component": "@/pages/1test.vue",
     "name": "1test",
     "path": "/1test",
+    "pathSegments": Array [
+      "1test",
+    ],
     "specifier": "_1Test",
   },
 ]
@@ -108,18 +148,25 @@ Array [
     "component": "@/pages/index.vue",
     "name": "index",
     "path": "/",
+    "pathSegments": Array [],
     "specifier": "Index",
   },
   Object {
     "component": "@/pages/foo.vue",
     "name": "foo",
     "path": "/foo",
+    "pathSegments": Array [
+      "foo",
+    ],
     "specifier": "Foo",
   },
   Object {
     "component": "@/pages/baz.vue",
     "name": "baz",
     "path": "/baz",
+    "pathSegments": Array [
+      "baz",
+    ],
     "specifier": "Baz",
   },
 ]
@@ -133,13 +180,188 @@ Array [
         "component": "@/pages/users/session/login.vue",
         "name": "users-session-login",
         "path": "session/login",
+        "pathSegments": Array [
+          "users",
+          "session",
+          "login",
+        ],
         "specifier": "UsersSessionLogin",
       },
     ],
     "component": "@/pages/users.vue",
     "name": "users",
     "path": "/users",
+    "pathSegments": Array [
+      "users",
+    ],
     "specifier": "Users",
+  },
+]
+`;
+
+exports[`Route resolution sorting handles when a dynamic route is a directory 1`] = `
+Array [
+  Object {
+    "component": "@/pages/nested/foo.vue",
+    "name": "nested-foo",
+    "path": "/nested/foo",
+    "pathSegments": Array [
+      "nested",
+      "foo",
+    ],
+    "specifier": "NestedFoo",
+  },
+  Object {
+    "component": "@/pages/nested/_id/foo.vue",
+    "name": "nested-id-foo",
+    "path": "/nested/:id/foo",
+    "pathSegments": Array [
+      "nested",
+      ":id",
+      "foo",
+    ],
+    "specifier": "NestedIdFoo",
+  },
+]
+`;
+
+exports[`Route resolution sorting handles when a static route is a directory 1`] = `
+Array [
+  Object {
+    "component": "@/pages/nested/foo/bar.vue",
+    "name": "nested-foo-bar",
+    "path": "/nested/foo/bar",
+    "pathSegments": Array [
+      "nested",
+      "foo",
+      "bar",
+    ],
+    "specifier": "NestedFooBar",
+  },
+  Object {
+    "component": "@/pages/nested/_id.vue",
+    "name": "nested-id",
+    "path": "/nested/:id",
+    "pathSegments": Array [
+      "nested",
+      ":id",
+    ],
+    "specifier": "NestedId",
+  },
+]
+`;
+
+exports[`Route resolution sorting handles when both static and dynamic routes are directories 1`] = `
+Array [
+  Object {
+    "component": "@/pages/nested/static/foo.vue",
+    "name": "nested-static-foo",
+    "path": "/nested/static/foo",
+    "pathSegments": Array [
+      "nested",
+      "static",
+      "foo",
+    ],
+    "specifier": "NestedStaticFoo",
+  },
+  Object {
+    "component": "@/pages/nested/_id/foo.vue",
+    "name": "nested-id-foo",
+    "path": "/nested/:id/foo",
+    "pathSegments": Array [
+      "nested",
+      ":id",
+      "foo",
+    ],
+    "specifier": "NestedIdFoo",
+  },
+]
+`;
+
+exports[`Route resolution sorting prioritizes deeper routes 1`] = `
+Array [
+  Object {
+    "component": "@/pages/nested/test/foo/bar.vue",
+    "name": "nested-test-foo-bar",
+    "path": "/nested/test/foo/bar",
+    "pathSegments": Array [
+      "nested",
+      "test",
+      "foo",
+      "bar",
+    ],
+    "specifier": "NestedTestFooBar",
+  },
+  Object {
+    "component": "@/pages/nested/test/foo/_id.vue",
+    "name": "nested-test-foo-id",
+    "path": "/nested/test/foo/:id",
+    "pathSegments": Array [
+      "nested",
+      "test",
+      "foo",
+      ":id",
+    ],
+    "specifier": "NestedTestFooId",
+  },
+  Object {
+    "component": "@/pages/nested/_id/foo/bar.vue",
+    "name": "nested-id-foo-bar",
+    "path": "/nested/:id/foo/bar",
+    "pathSegments": Array [
+      "nested",
+      ":id",
+      "foo",
+      "bar",
+    ],
+    "specifier": "NestedIdFooBar",
+  },
+  Object {
+    "component": "@/pages/nested/_id/_key/bar.vue",
+    "name": "nested-id-key-bar",
+    "path": "/nested/:id/:key/bar",
+    "pathSegments": Array [
+      "nested",
+      ":id",
+      ":key",
+      "bar",
+    ],
+    "specifier": "NestedIdKeyBar",
+  },
+]
+`;
+
+exports[`Route resolution sorting prioritizes static routes than dynamic ones 1`] = `
+Array [
+  Object {
+    "component": "@/pages/nested/foo.vue",
+    "name": "nested-foo",
+    "path": "/nested/foo",
+    "pathSegments": Array [
+      "nested",
+      "foo",
+    ],
+    "specifier": "NestedFoo",
+  },
+  Object {
+    "component": "@/pages/nested/bar.vue",
+    "name": "nested-bar",
+    "path": "/nested/bar",
+    "pathSegments": Array [
+      "nested",
+      "bar",
+    ],
+    "specifier": "NestedBar",
+  },
+  Object {
+    "component": "@/pages/nested/_id.vue",
+    "name": "nested-id",
+    "path": "/nested/:id",
+    "pathSegments": Array [
+      "nested",
+      ":id",
+    ],
+    "specifier": "NestedId",
   },
 ]
 `;

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -19,6 +19,12 @@ Array [
   Object {
     "children": Array [
       Object {
+        "component": "@/pages/users/test.vue",
+        "name": "users-test",
+        "path": "test",
+        "specifier": "UsersTest",
+      },
+      Object {
         "children": Array [
           Object {
             "component": "@/pages/users/_id/foo.vue",
@@ -31,12 +37,6 @@ Array [
         "name": "users-id",
         "path": ":id",
         "specifier": "UsersId",
-      },
-      Object {
-        "component": "@/pages/users/test.vue",
-        "name": "users-test",
-        "path": "test",
-        "specifier": "UsersTest",
       },
     ],
     "component": "@/pages/users.vue",

--- a/test/resolve.spec.ts
+++ b/test/resolve.spec.ts
@@ -55,4 +55,34 @@ describe('Route resolution', () => {
       /Invalid json format of <route-meta> content in invalid-meta\.vue/
     )
   })
+
+  describe('sorting', () => {
+    test('prioritizes static routes than dynamic ones', [
+      'nested/foo.vue',
+      'nested/_id.vue',
+      'nested/bar.vue'
+    ])
+
+    test('prioritizes deeper routes', [
+      'nested/_id/foo/bar.vue',
+      'nested/_id/_key/bar.vue',
+      'nested/test/foo/bar.vue',
+      'nested/test/foo/_id.vue'
+    ])
+
+    test('handles when a dynamic route is a directory', [
+      'nested/_id/foo.vue',
+      'nested/foo.vue'
+    ])
+
+    test('handles when a static route is a directory', [
+      'nested/_id.vue',
+      'nested/foo/bar.vue'
+    ])
+
+    test('handles when both static and dynamic routes are directories', [
+      'nested/_id/foo.vue',
+      'nested/static/foo.vue'
+    ])
+  })
 })


### PR DESCRIPTION
This is taken over from #4.

The converted `PageMeta` structure may not be the same as the actual route structure because intermediate routes may not be there in real. I stated about that on https://github.com/ktsn/vue-route-generator/pull/4#discussion_r209484427.

So we need to sort the `PageMeta` data by seeing each path **segment** rather than whole path. `routePathComparator` does this job to check path segments recursively.

I also added `pathSegments` field on `PageMeta` to use path segments after flattened the meta data.