### PR TITLE
feat: add nested option

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ module.exports = [
 - `pages`: Path to the directory that contains your page components.
 - `importPrefix`: A string that will be added to importing component path (default `@/pages/`).
 - `dynamicImport`: Use dynamic import expression (`import()`) to import component (default `true`).
+- `nested`: If `true`, generated route path will be always treated as nested. (e.g. will generate `path: 'foo'` rather than `path: '/foo'`)
 
 ## Related Projects
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,14 @@ export interface GenerateConfig {
   pages: string
   importPrefix?: string
   dynamicImport?: boolean
+  nested?: boolean
 }
 
 export function generateRoutes({
   pages,
   importPrefix = '@/pages/',
-  dynamicImport = true
+  dynamicImport = true,
+  nested = false
 }: GenerateConfig): string {
   const patterns = ['**/*.vue', '!**/__*__.vue', '!**/__*__/**']
 
@@ -22,7 +24,7 @@ export function generateRoutes({
     onlyFiles: true
   })
 
-  const metaList = resolveRoutePaths(pagePaths, importPrefix, file => {
+  const metaList = resolveRoutePaths(pagePaths, importPrefix, nested, file => {
     return fs.readFileSync(path.join(pages, file), 'utf8')
   })
 

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -17,6 +17,27 @@ Array [
 ]
 `;
 
+exports[`Route resolution resolves as nested routes 1`] = `
+Array [
+  Object {
+    "component": "@/pages/index.vue",
+    "name": "index",
+    "path": "",
+    "pathSegments": Array [],
+    "specifier": "Index",
+  },
+  Object {
+    "component": "@/pages/foo.vue",
+    "name": "foo",
+    "path": "foo",
+    "pathSegments": Array [
+      "foo",
+    ],
+    "specifier": "Foo",
+  },
+]
+`;
+
 exports[`Route resolution resolves dynamic nested routes 1`] = `
 Array [
   Object {

--- a/test/resolve.spec.ts
+++ b/test/resolve.spec.ts
@@ -21,10 +21,10 @@ function mockReadFile(path: string): string {
 }
 
 describe('Route resolution', () => {
-  function test(name: string, paths: string[]): void {
+  function test(name: string, paths: string[], nested: boolean = false): void {
     it(name, () => {
       expect(
-        resolveRoutePaths(paths, '@/pages/', mockReadFile)
+        resolveRoutePaths(paths, '@/pages/', nested, mockReadFile)
       ).toMatchSnapshot()
     })
   }
@@ -50,9 +50,11 @@ describe('Route resolution', () => {
 
   test('resolve route meta', ['meta.vue'])
 
+  test('resolves as nested routes', ['index.vue', 'foo.vue'], true)
+
   it('throws error when failed to parse route-meta', () => {
     expect(() => {
-      resolveRoutePaths(['invalid-meta.vue'], '@/pages/', mockReadFile)
+      resolveRoutePaths(['invalid-meta.vue'], '@/pages/', false, mockReadFile)
     }).toThrow(
       /Invalid json format of <route-meta> content in invalid-meta\.vue/
     )


### PR DESCRIPTION
Sometimes we want to pass generated routes into some other parent route. For example, [vue-cli-plugin-auto-routing](https://github.com/ktsn/vue-cli-plugin-auto-routing) does that to handle layouting. For example:

```js
import Vue from 'vue'
import Router from 'vue-router'
import routes from 'vue-auto-routing'
import { createRouterLayout } from 'vue-router-layout'

Vue.use(Router)

const RouterLayout = createRouterLayout(layout => {
  return import('@/layouts/' + layout + '.vue')
})

export default new Router({
  routes: [
    {
      path: '/some-route',
      component: RouterLayout,
      children: routes
    }
  ]

```

In this case, if routes in `routes` variable has a path which started with `/`, the router ignore the `/some-route` path. To handle such situation, we need `nested` flag to always generate the route as nested one.