### PR TITLE
fix: avoid warning when there is default child route

### DIFF
--- a/src/template/routes.ts
+++ b/src/template/routes.ts
@@ -2,20 +2,25 @@ import * as prettier from 'prettier'
 import { PageMeta } from '../resolve'
 
 function createChildrenRoute(children: PageMeta[]): string {
-  return `,
-    children: [${children.map(createRoute).join(',')}]`
+  return `,children: [${children.map(createRoute).join(',')}]`
 }
 
 function createRoute(meta: PageMeta): string {
   const children = !meta.children ? '' : createChildrenRoute(meta.children)
 
+  // If default child is exists, the route should not have a name.
+  const routeName =
+    meta.children && meta.children.some(m => m.path === '')
+      ? ''
+      : `name: '${meta.name}',`
+
   const routeMeta = !meta.routeMeta
     ? ''
-    : ',\nmeta: ' + JSON.stringify(meta.routeMeta, null, 2)
+    : ',meta: ' + JSON.stringify(meta.routeMeta, null, 2)
 
   return `
   {
-    name: '${meta.name}',
+    ${routeName}
     path: '${meta.path}',
     component: ${meta.specifier}${routeMeta}${children}
   }`

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -22,7 +22,6 @@ export default [
     component: Index
   },
   {
-    name: 'foo',
     path: '/foo',
     component: Foo,
     children: [

--- a/test/__snapshots__/route-template.spec.ts.snap
+++ b/test/__snapshots__/route-template.spec.ts.snap
@@ -80,3 +80,24 @@ export default [
 ]
 "
 `;
+
+exports[`Route template should not include name if the route has a default child 1`] = `
+"const Foo = () => import(/* webpackChunkName: \\"foo\\" */ '@/pages/foo.vue')
+const FooIndex = () =>
+  import(/* webpackChunkName: \\"foo-index\\" */ '@/pages/foo/index.vue')
+
+export default [
+  {
+    path: '/foo',
+    component: Foo,
+    children: [
+      {
+        name: 'foo-index',
+        path: '',
+        component: FooIndex
+      }
+    ]
+  }
+]
+"
+`;

--- a/test/route-template.spec.ts
+++ b/test/route-template.spec.ts
@@ -90,4 +90,27 @@ describe('Route template', () => {
 
     expect(createRoutes(meta, false)).toMatchSnapshot()
   })
+
+  it('should not include name if the route has a default child', () => {
+    const meta: PageMeta[] = [
+      {
+        name: 'foo',
+        specifier: 'Foo',
+        path: '/foo',
+        pathSegments: ['foo'],
+        component: '@/pages/foo.vue',
+        children: [
+          {
+            name: 'foo-index',
+            specifier: 'FooIndex',
+            path: '',
+            pathSegments: ['foo'],
+            component: '@/pages/foo/index.vue'
+          }
+        ]
+      }
+    ]
+
+    expect(createRoutes(meta, true)).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
fix #14 