### PR TITLE
feat: support <route> custom block

### DIFF
--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -16,8 +16,8 @@ function FooBar() {
 function FooId() {
   return import(/* webpackChunkName: \\"foo-id\\" */ '@/pages/foo/_id.vue')
 }
-function Meta() {
-  return import(/* webpackChunkName: \\"meta\\" */ '@/pages/meta.vue')
+function Route() {
+  return import(/* webpackChunkName: \\"route\\" */ '@/pages/route.vue')
 }
 function UserRegister() {
   return import(
@@ -59,9 +59,9 @@ export default [
     ],
   },
   {
-    name: 'meta',
-    path: '/meta',
-    component: Meta,
+    name: 'Test',
+    path: '/route',
+    component: Route,
     meta: {
       requiresAuth: true,
     },

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -34,6 +34,26 @@ Array [
 ]
 `;
 
+exports[`Route resolution resolve route custom block 1`] = `
+Array [
+  Object {
+    "component": "@/pages/route.vue",
+    "name": "route",
+    "path": "/route",
+    "pathSegments": Array [
+      "route",
+    ],
+    "route": Object {
+      "meta": Object {
+        "title": "Hello",
+      },
+      "name": "Test",
+    },
+    "specifier": "Route",
+  },
+]
+`;
+
 exports[`Route resolution resolve route meta 1`] = `
 Array [
   Object {

--- a/test/__snapshots__/route-template.spec.ts.snap
+++ b/test/__snapshots__/route-template.spec.ts.snap
@@ -114,6 +114,23 @@ export default [
 "
 `;
 
+exports[`Route template should merge route block into route record 1`] = `
+"import Foo from '@/pages/foo.vue'
+
+export default [
+  {
+    name: 'Test',
+    path: '/foo',
+    component: Foo,
+    meta: {
+      title: 'Hello',
+    },
+    props: true,
+  },
+]
+"
+`;
+
 exports[`Route template should not include name if the route has a default child 1`] = `
 "function Foo() {
   return import(/* webpackChunkName: \\"foo\\" */ '@/pages/foo.vue')

--- a/test/fixtures/meta.vue
+++ b/test/fixtures/meta.vue
@@ -1,5 +1,0 @@
-<route-meta>
-{
-  "requiresAuth": true
-}
-</route-meta>

--- a/test/fixtures/route.vue
+++ b/test/fixtures/route.vue
@@ -1,0 +1,8 @@
+<route>
+{
+  "name": "Test",
+  "meta": {
+    "requiresAuth": true
+  }
+}
+</route>

--- a/test/route-template.spec.ts
+++ b/test/route-template.spec.ts
@@ -91,6 +91,27 @@ describe('Route template', () => {
     expect(createRoutes(meta, false, '')).toMatchSnapshot()
   })
 
+  it('should merge route block into route record', () => {
+    const meta: PageMeta[] = [
+      {
+        name: 'foo',
+        specifier: 'Foo',
+        path: '/foo',
+        pathSegments: ['foo'],
+        component: '@/pages/foo.vue',
+        route: {
+          name: 'Test',
+          meta: {
+            title: 'Hello',
+          },
+          props: true,
+        },
+      },
+    ]
+
+    expect(createRoutes(meta, false, '')).toMatchSnapshot()
+  })
+
   it('should configure chunk name prefix', () => {
     const meta: PageMeta[] = [
       {


### PR DESCRIPTION
DEPRECATED: `<route-meta>` is deprecated in favor of `<route>`

fix #67 
fix #144
fix ktsn/vue-auto-routing#21

It supports `<route>` custom block which allows users to overwrite route record.

Example users.vue:

```vue
<route>
{
  "name": "UserPage",
  "props": true
}
</route>
```

The following route record will be generated:

```js
routes: [
  {
    name: "UserPage",
    props: true,
    path: '/users',
    component: Users
  }
]
```

Note that it does not allow to overwrite `path` and `component` option.