### PR TITLE
fix: do not include index in path when there is no corresponding index.vue

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -87,7 +87,7 @@ function pathMapToMeta(
         importPrefix,
         nested,
         readFile,
-        path.length
+        meta.pathSegments.length
       )
     }
 
@@ -177,21 +177,18 @@ function isOmittable(segment: string): boolean {
 function toActualPath(segments: string[]): string[] {
   const lastIndex = segments.length - 1
   const last = basename(segments[lastIndex])
+  segments = segments.slice(0, -1).concat(last)
 
-  if (isOmittable(last)) {
-    segments = segments.slice(0, -1)
-  } else {
-    segments = segments.slice(0, -1).concat(last)
-  }
-
-  return segments.map((s, i) => {
-    if (s[0] === '_') {
-      const suffix = lastIndex === i ? '?' : ''
-      return ':' + s.slice(1) + suffix
-    } else {
-      return s
-    }
-  })
+  return segments
+    .filter((s) => !isOmittable(s))
+    .map((s, i) => {
+      if (s[0] === '_') {
+        const suffix = lastIndex === i ? '?' : ''
+        return ':' + s.slice(1) + suffix
+      } else {
+        return s
+      }
+    })
 }
 
 function pathToMapPath(segments: string[]): string[] {

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -185,6 +185,61 @@ Array [
 ]
 `;
 
+exports[`Route resolution resolves nested route including index 1`] = `
+Array [
+  Object {
+    "component": "@/pages/a/index/b/index/c.vue",
+    "name": "a-index-b-index-c",
+    "path": "/a/b/c",
+    "pathSegments": Array [
+      "a",
+      "b",
+      "c",
+    ],
+    "specifier": "AIndexBIndexC",
+  },
+]
+`;
+
+exports[`Route resolution resolves nested route including index with corresponding index.vue 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "component": "@/pages/a/index/b/index/c.vue",
+            "name": "a-index-b-index-c",
+            "path": "c",
+            "pathSegments": Array [
+              "a",
+              "b",
+              "c",
+            ],
+            "specifier": "AIndexBIndexC",
+          },
+        ],
+        "component": "@/pages/a/index/b/index.vue",
+        "name": "a-index-b-index",
+        "path": "b",
+        "pathSegments": Array [
+          "a",
+          "b",
+        ],
+        "specifier": "AIndexBIndex",
+      },
+    ],
+    "component": "@/pages/a/index.vue",
+    "name": "a-index",
+    "path": "/a",
+    "pathSegments": Array [
+      "a",
+    ],
+    "specifier": "AIndex",
+  },
+]
+`;
+
 exports[`Route resolution resolves nested routes 1`] = `
 Array [
   Object {

--- a/test/resolve.spec.ts
+++ b/test/resolve.spec.ts
@@ -65,6 +65,14 @@ describe('Route resolution', () => {
 
   test('resolves routes', ['index.vue', 'foo.vue', 'baz.vue'])
 
+  test('resolves nested route including index', ['a/index/b/index/c.vue'])
+
+  test('resolves nested route including index with corresponding index.vue', [
+    'a/index.vue',
+    'a/index/b/index.vue',
+    'a/index/b/index/c.vue',
+  ])
+
   test('resolves dynamic routes', ['users/_id.vue'])
 
   test('resolves dynamic routes with multiple "."', ['user.register.vue'])


### PR DESCRIPTION
Let's say the below case:

```
-- a/
    |- index/
        |- b.vue
```

vue-route-generator generates a route with `path: '/a/index/b'` which is wrong. Expected route is with `path: '/a/b'`. 