### PR TITLE
fix: omit index from route name

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -3,6 +3,7 @@ import { NestedMap, setToMap } from './nested-map'
 
 export interface PageMeta {
   name: string
+  chunkName: string
   specifier: string
   path: string
   pathSegments: string[]
@@ -47,6 +48,7 @@ function pathMapToMeta(
 
     const meta: PageMeta = {
       name: pathToName(path),
+      chunkName: pathToChunkName(path),
       specifier: pathToSpecifier(path),
       path: pathToRoute(path, parentDepth, nested),
       pathSegments: toActualPath(path),
@@ -198,6 +200,24 @@ function pathToMapPath(segments: string[]): string[] {
 
 function pathToName(segments: string[]): string {
   const last = segments[segments.length - 1]
+  segments = segments
+    .slice(0, -1)
+    .concat(basename(last))
+    .filter((s) => !isOmittable(s))
+
+  if (segments.length === 0) {
+    return 'index'
+  }
+
+  return segments
+    .map((s) => {
+      return s[0] === '_' ? s.slice(1) : s
+    })
+    .join('-')
+}
+
+function pathToChunkName(segments: string[]): string {
+  const last = segments[segments.length - 1]
   segments = segments.slice(0, -1).concat(basename(last))
 
   return segments
@@ -208,12 +228,12 @@ function pathToName(segments: string[]): string {
 }
 
 function pathToSpecifier(segments: string[]): string {
-  const name = pathToName(segments)
-  const replaced = name
-    .replace(/(^|[^a-zA-Z])([a-zA-Z])/g, (_, a, b) => {
-      return a + b.toUpperCase()
-    })
-    .replace(/[^a-zA-Z0-9]/g, '')
+  const last = segments[segments.length - 1]
+  const replaced = segments
+    .slice(0, -1)
+    .concat(basename(last))
+    .join('_')
+    .replace(/[^a-zA-Z0-9]/g, '_')
 
   return /^\d/.test(replaced) ? '_' + replaced : replaced
 }

--- a/src/template/routes.ts
+++ b/src/template/routes.ts
@@ -44,7 +44,7 @@ function createImport(
   chunkNamePrefix: string
 ): string {
   const code = dynamic
-    ? `function ${meta.specifier}() { return import(/* webpackChunkName: "${chunkNamePrefix}${meta.name}" */ '${meta.component}') }`
+    ? `function ${meta.specifier}() { return import(/* webpackChunkName: "${chunkNamePrefix}${meta.chunkName}" */ '${meta.component}') }`
     : `import ${meta.specifier} from '${meta.component}'`
 
   return meta.children

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -1,33 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Integration test 1`] = `
-"function Index() {
+"function index() {
   return import(/* webpackChunkName: \\"index\\" */ '@/pages/index.vue')
 }
-function Foo() {
+function foo() {
   return import(/* webpackChunkName: \\"foo\\" */ '@/pages/foo.vue')
 }
-function FooIndex() {
+function foo_index() {
   return import(/* webpackChunkName: \\"foo-index\\" */ '@/pages/foo/index.vue')
 }
-function FooBar() {
+function foo_bar() {
   return import(/* webpackChunkName: \\"foo-bar\\" */ '@/pages/foo/bar.vue')
 }
-function FooId() {
+function foo__id() {
   return import(/* webpackChunkName: \\"foo-id\\" */ '@/pages/foo/_id.vue')
 }
-function Route() {
+function route() {
   return import(/* webpackChunkName: \\"route\\" */ '@/pages/route.vue')
 }
-function UserRegister() {
+function user_register() {
   return import(
     /* webpackChunkName: \\"user.register\\" */ '@/pages/user.register.vue'
   )
 }
-function IdIndex() {
+function _id_index() {
   return import(/* webpackChunkName: \\"id-index\\" */ '@/pages/_id/index.vue')
 }
-function IdTest() {
+function _id_test() {
   return import(/* webpackChunkName: \\"id-test\\" */ '@/pages/_id/test.vue')
 }
 
@@ -35,33 +35,33 @@ export default [
   {
     name: 'index',
     path: '/',
-    component: Index,
+    component: index,
   },
   {
     path: '/foo',
-    component: Foo,
+    component: foo,
     children: [
       {
-        name: 'foo-index',
+        name: 'foo',
         path: '',
-        component: FooIndex,
+        component: foo_index,
       },
       {
         name: 'foo-bar',
         path: 'bar',
-        component: FooBar,
+        component: foo_bar,
       },
       {
         name: 'foo-id',
         path: ':id?',
-        component: FooId,
+        component: foo__id,
       },
     ],
   },
   {
     name: 'Test',
     path: '/route',
-    component: Route,
+    component: route,
     meta: {
       requiresAuth: true,
     },
@@ -69,17 +69,17 @@ export default [
   {
     name: 'user.register',
     path: '/user.register',
-    component: UserRegister,
+    component: user_register,
   },
   {
-    name: 'id-index',
+    name: 'id',
     path: '/:id',
-    component: IdIndex,
+    component: _id_index,
   },
   {
     name: 'id-test',
     path: '/:id/test',
-    component: IdTest,
+    component: _id_test,
   },
 ]
 "

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -3,15 +3,17 @@
 exports[`Route resolution prioritizes index than dynamic route 1`] = `
 Array [
   Object {
+    "chunkName": "users-index",
     "component": "@/pages/users/index.vue",
-    "name": "users-index",
+    "name": "users",
     "path": "/users",
     "pathSegments": Array [
       "users",
     ],
-    "specifier": "UsersIndex",
+    "specifier": "users_index",
   },
   Object {
+    "chunkName": "users-foo",
     "component": "@/pages/users/foo.vue",
     "name": "users-foo",
     "path": "/users/foo",
@@ -19,9 +21,10 @@ Array [
       "users",
       "foo",
     ],
-    "specifier": "UsersFoo",
+    "specifier": "users_foo",
   },
   Object {
+    "chunkName": "users-id",
     "component": "@/pages/users/_id.vue",
     "name": "users-id",
     "path": "/users/:id?",
@@ -29,7 +32,7 @@ Array [
       "users",
       ":id?",
     ],
-    "specifier": "UsersId",
+    "specifier": "users__id",
   },
 ]
 `;
@@ -37,6 +40,7 @@ Array [
 exports[`Route resolution resolve route custom block 1`] = `
 Array [
   Object {
+    "chunkName": "route",
     "component": "@/pages/route.vue",
     "name": "route",
     "path": "/route",
@@ -49,7 +53,7 @@ Array [
       },
       "name": "Test",
     },
-    "specifier": "Route",
+    "specifier": "route",
   },
 ]
 `;
@@ -57,6 +61,7 @@ Array [
 exports[`Route resolution resolve route meta 1`] = `
 Array [
   Object {
+    "chunkName": "meta",
     "component": "@/pages/meta.vue",
     "name": "meta",
     "path": "/meta",
@@ -66,7 +71,7 @@ Array [
     "routeMeta": Object {
       "title": "Hello",
     },
-    "specifier": "Meta",
+    "specifier": "meta",
   },
 ]
 `;
@@ -74,20 +79,22 @@ Array [
 exports[`Route resolution resolves as nested routes 1`] = `
 Array [
   Object {
+    "chunkName": "index",
     "component": "@/pages/index.vue",
     "name": "index",
     "path": "",
     "pathSegments": Array [],
-    "specifier": "Index",
+    "specifier": "index",
   },
   Object {
+    "chunkName": "foo",
     "component": "@/pages/foo.vue",
     "name": "foo",
     "path": "foo",
     "pathSegments": Array [
       "foo",
     ],
-    "specifier": "Foo",
+    "specifier": "foo",
   },
 ]
 `;
@@ -97,6 +104,7 @@ Array [
   Object {
     "children": Array [
       Object {
+        "chunkName": "users-test",
         "component": "@/pages/users/test.vue",
         "name": "users-test",
         "path": "test",
@@ -104,11 +112,12 @@ Array [
           "users",
           "test",
         ],
-        "specifier": "UsersTest",
+        "specifier": "users_test",
       },
       Object {
         "children": Array [
           Object {
+            "chunkName": "users-id-foo",
             "component": "@/pages/users/_id/foo.vue",
             "name": "users-id-foo",
             "path": "foo",
@@ -117,9 +126,10 @@ Array [
               ":id",
               "foo",
             ],
-            "specifier": "UsersIdFoo",
+            "specifier": "users__id_foo",
           },
         ],
+        "chunkName": "users-id",
         "component": "@/pages/users/_id.vue",
         "name": "users-id",
         "path": ":id?",
@@ -127,16 +137,17 @@ Array [
           "users",
           ":id?",
         ],
-        "specifier": "UsersId",
+        "specifier": "users__id",
       },
     ],
+    "chunkName": "users",
     "component": "@/pages/users.vue",
     "name": "users",
     "path": "/users",
     "pathSegments": Array [
       "users",
     ],
-    "specifier": "Users",
+    "specifier": "users",
   },
 ]
 `;
@@ -144,6 +155,7 @@ Array [
 exports[`Route resolution resolves dynamic routes 1`] = `
 Array [
   Object {
+    "chunkName": "users-id",
     "component": "@/pages/users/_id.vue",
     "name": "users-id",
     "path": "/users/:id?",
@@ -151,7 +163,7 @@ Array [
       "users",
       ":id?",
     ],
-    "specifier": "UsersId",
+    "specifier": "users__id",
   },
 ]
 `;
@@ -159,13 +171,14 @@ Array [
 exports[`Route resolution resolves dynamic routes with multiple "." 1`] = `
 Array [
   Object {
+    "chunkName": "user.register",
     "component": "@/pages/user.register.vue",
     "name": "user.register",
     "path": "/user.register",
     "pathSegments": Array [
       "user.register",
     ],
-    "specifier": "UserRegister",
+    "specifier": "user_register",
   },
 ]
 `;
@@ -173,14 +186,15 @@ Array [
 exports[`Route resolution resolves dynamic routes with required param 1`] = `
 Array [
   Object {
+    "chunkName": "users-id-index",
     "component": "@/pages/users/_id/index.vue",
-    "name": "users-id-index",
+    "name": "users-id",
     "path": "/users/:id",
     "pathSegments": Array [
       "users",
       ":id",
     ],
-    "specifier": "UsersIdIndex",
+    "specifier": "users__id_index",
   },
 ]
 `;
@@ -188,15 +202,16 @@ Array [
 exports[`Route resolution resolves nested route including index 1`] = `
 Array [
   Object {
+    "chunkName": "a-index-b-index-c",
     "component": "@/pages/a/index/b/index/c.vue",
-    "name": "a-index-b-index-c",
+    "name": "a-b-c",
     "path": "/a/b/c",
     "pathSegments": Array [
       "a",
       "b",
       "c",
     ],
-    "specifier": "AIndexBIndexC",
+    "specifier": "a_index_b_index_c",
   },
 ]
 `;
@@ -208,34 +223,37 @@ Array [
       Object {
         "children": Array [
           Object {
+            "chunkName": "a-index-b-index-c",
             "component": "@/pages/a/index/b/index/c.vue",
-            "name": "a-index-b-index-c",
+            "name": "a-b-c",
             "path": "c",
             "pathSegments": Array [
               "a",
               "b",
               "c",
             ],
-            "specifier": "AIndexBIndexC",
+            "specifier": "a_index_b_index_c",
           },
         ],
+        "chunkName": "a-index-b-index",
         "component": "@/pages/a/index/b/index.vue",
-        "name": "a-index-b-index",
+        "name": "a-b",
         "path": "b",
         "pathSegments": Array [
           "a",
           "b",
         ],
-        "specifier": "AIndexBIndex",
+        "specifier": "a_index_b_index",
       },
     ],
+    "chunkName": "a-index",
     "component": "@/pages/a/index.vue",
-    "name": "a-index",
+    "name": "a",
     "path": "/a",
     "pathSegments": Array [
       "a",
     ],
-    "specifier": "AIndex",
+    "specifier": "a_index",
   },
 ]
 `;
@@ -245,15 +263,17 @@ Array [
   Object {
     "children": Array [
       Object {
+        "chunkName": "foo-index",
         "component": "@/pages/foo/index.vue",
-        "name": "foo-index",
+        "name": "foo",
         "path": "",
         "pathSegments": Array [
           "foo",
         ],
-        "specifier": "FooIndex",
+        "specifier": "foo_index",
       },
       Object {
+        "chunkName": "foo-bar",
         "component": "@/pages/foo/bar.vue",
         "name": "foo-bar",
         "path": "bar",
@@ -261,16 +281,17 @@ Array [
           "foo",
           "bar",
         ],
-        "specifier": "FooBar",
+        "specifier": "foo_bar",
       },
     ],
+    "chunkName": "foo",
     "component": "@/pages/foo.vue",
     "name": "foo",
     "path": "/foo",
     "pathSegments": Array [
       "foo",
     ],
-    "specifier": "Foo",
+    "specifier": "foo",
   },
 ]
 `;
@@ -280,6 +301,7 @@ Array [
   Object {
     "children": Array [
       Object {
+        "chunkName": "1test-2nested",
         "component": "@/pages/1test/2nested.vue",
         "name": "1test-2nested",
         "path": "2nested",
@@ -287,16 +309,17 @@ Array [
           "1test",
           "2nested",
         ],
-        "specifier": "_1Test2Nested",
+        "specifier": "_1test_2nested",
       },
     ],
+    "chunkName": "1test",
     "component": "@/pages/1test.vue",
     "name": "1test",
     "path": "/1test",
     "pathSegments": Array [
       "1test",
     ],
-    "specifier": "_1Test",
+    "specifier": "_1test",
   },
 ]
 `;
@@ -304,29 +327,32 @@ Array [
 exports[`Route resolution resolves routes 1`] = `
 Array [
   Object {
+    "chunkName": "index",
     "component": "@/pages/index.vue",
     "name": "index",
     "path": "/",
     "pathSegments": Array [],
-    "specifier": "Index",
+    "specifier": "index",
   },
   Object {
+    "chunkName": "foo",
     "component": "@/pages/foo.vue",
     "name": "foo",
     "path": "/foo",
     "pathSegments": Array [
       "foo",
     ],
-    "specifier": "Foo",
+    "specifier": "foo",
   },
   Object {
+    "chunkName": "baz",
     "component": "@/pages/baz.vue",
     "name": "baz",
     "path": "/baz",
     "pathSegments": Array [
       "baz",
     ],
-    "specifier": "Baz",
+    "specifier": "baz",
   },
 ]
 `;
@@ -336,6 +362,7 @@ Array [
   Object {
     "children": Array [
       Object {
+        "chunkName": "users-session-login",
         "component": "@/pages/users/session/login.vue",
         "name": "users-session-login",
         "path": "session/login",
@@ -344,16 +371,17 @@ Array [
           "session",
           "login",
         ],
-        "specifier": "UsersSessionLogin",
+        "specifier": "users_session_login",
       },
     ],
+    "chunkName": "users",
     "component": "@/pages/users.vue",
     "name": "users",
     "path": "/users",
     "pathSegments": Array [
       "users",
     ],
-    "specifier": "Users",
+    "specifier": "users",
   },
 ]
 `;
@@ -361,6 +389,7 @@ Array [
 exports[`Route resolution sorting handles when a dynamic route is a directory 1`] = `
 Array [
   Object {
+    "chunkName": "nested-foo",
     "component": "@/pages/nested/foo.vue",
     "name": "nested-foo",
     "path": "/nested/foo",
@@ -368,9 +397,10 @@ Array [
       "nested",
       "foo",
     ],
-    "specifier": "NestedFoo",
+    "specifier": "nested_foo",
   },
   Object {
+    "chunkName": "nested-id-foo",
     "component": "@/pages/nested/_id/foo.vue",
     "name": "nested-id-foo",
     "path": "/nested/:id/foo",
@@ -379,7 +409,7 @@ Array [
       ":id",
       "foo",
     ],
-    "specifier": "NestedIdFoo",
+    "specifier": "nested__id_foo",
   },
 ]
 `;
@@ -387,6 +417,7 @@ Array [
 exports[`Route resolution sorting handles when a static route is a directory 1`] = `
 Array [
   Object {
+    "chunkName": "nested-foo-bar",
     "component": "@/pages/nested/foo/bar.vue",
     "name": "nested-foo-bar",
     "path": "/nested/foo/bar",
@@ -395,9 +426,10 @@ Array [
       "foo",
       "bar",
     ],
-    "specifier": "NestedFooBar",
+    "specifier": "nested_foo_bar",
   },
   Object {
+    "chunkName": "nested-id",
     "component": "@/pages/nested/_id.vue",
     "name": "nested-id",
     "path": "/nested/:id?",
@@ -405,7 +437,7 @@ Array [
       "nested",
       ":id?",
     ],
-    "specifier": "NestedId",
+    "specifier": "nested__id",
   },
 ]
 `;
@@ -413,6 +445,7 @@ Array [
 exports[`Route resolution sorting handles when both static and dynamic routes are directories 1`] = `
 Array [
   Object {
+    "chunkName": "nested-static-foo",
     "component": "@/pages/nested/static/foo.vue",
     "name": "nested-static-foo",
     "path": "/nested/static/foo",
@@ -421,9 +454,10 @@ Array [
       "static",
       "foo",
     ],
-    "specifier": "NestedStaticFoo",
+    "specifier": "nested_static_foo",
   },
   Object {
+    "chunkName": "nested-id-foo",
     "component": "@/pages/nested/_id/foo.vue",
     "name": "nested-id-foo",
     "path": "/nested/:id/foo",
@@ -432,7 +466,7 @@ Array [
       ":id",
       "foo",
     ],
-    "specifier": "NestedIdFoo",
+    "specifier": "nested__id_foo",
   },
 ]
 `;
@@ -440,6 +474,7 @@ Array [
 exports[`Route resolution sorting prioritizes deeper routes 1`] = `
 Array [
   Object {
+    "chunkName": "nested-test-foo-bar",
     "component": "@/pages/nested/test/foo/bar.vue",
     "name": "nested-test-foo-bar",
     "path": "/nested/test/foo/bar",
@@ -449,9 +484,10 @@ Array [
       "foo",
       "bar",
     ],
-    "specifier": "NestedTestFooBar",
+    "specifier": "nested_test_foo_bar",
   },
   Object {
+    "chunkName": "nested-test-foo-id",
     "component": "@/pages/nested/test/foo/_id.vue",
     "name": "nested-test-foo-id",
     "path": "/nested/test/foo/:id?",
@@ -461,9 +497,10 @@ Array [
       "foo",
       ":id?",
     ],
-    "specifier": "NestedTestFooId",
+    "specifier": "nested_test_foo__id",
   },
   Object {
+    "chunkName": "nested-id-foo-bar",
     "component": "@/pages/nested/_id/foo/bar.vue",
     "name": "nested-id-foo-bar",
     "path": "/nested/:id/foo/bar",
@@ -473,9 +510,10 @@ Array [
       "foo",
       "bar",
     ],
-    "specifier": "NestedIdFooBar",
+    "specifier": "nested__id_foo_bar",
   },
   Object {
+    "chunkName": "nested-id-key-bar",
     "component": "@/pages/nested/_id/_key/bar.vue",
     "name": "nested-id-key-bar",
     "path": "/nested/:id/:key/bar",
@@ -485,7 +523,7 @@ Array [
       ":key",
       "bar",
     ],
-    "specifier": "NestedIdKeyBar",
+    "specifier": "nested__id__key_bar",
   },
 ]
 `;
@@ -493,6 +531,7 @@ Array [
 exports[`Route resolution sorting prioritizes static routes than dynamic ones 1`] = `
 Array [
   Object {
+    "chunkName": "nested-foo",
     "component": "@/pages/nested/foo.vue",
     "name": "nested-foo",
     "path": "/nested/foo",
@@ -500,9 +539,10 @@ Array [
       "nested",
       "foo",
     ],
-    "specifier": "NestedFoo",
+    "specifier": "nested_foo",
   },
   Object {
+    "chunkName": "nested-bar",
     "component": "@/pages/nested/bar.vue",
     "name": "nested-bar",
     "path": "/nested/bar",
@@ -510,9 +550,10 @@ Array [
       "nested",
       "bar",
     ],
-    "specifier": "NestedBar",
+    "specifier": "nested_bar",
   },
   Object {
+    "chunkName": "nested-id",
     "component": "@/pages/nested/_id.vue",
     "name": "nested-id",
     "path": "/nested/:id?",
@@ -520,7 +561,7 @@ Array [
       "nested",
       ":id?",
     ],
-    "specifier": "NestedId",
+    "specifier": "nested__id",
   },
 ]
 `;

--- a/test/__snapshots__/route-template.spec.ts.snap
+++ b/test/__snapshots__/route-template.spec.ts.snap
@@ -145,11 +145,28 @@ export default [
     component: Foo,
     children: [
       {
-        name: 'foo-index',
+        name: 'foo',
         path: '',
         component: FooIndex,
       },
     ],
+  },
+]
+"
+`;
+
+exports[`Route template should pick chunkName as a webpack chunk name 1`] = `
+"function users_index() {
+  return import(
+    /* webpackChunkName: \\"page-users-index\\" */ '@/pages/users/index.vue'
+  )
+}
+
+export default [
+  {
+    name: 'users',
+    path: '/users',
+    component: users_index,
   },
 ]
 "

--- a/test/route-template.spec.ts
+++ b/test/route-template.spec.ts
@@ -6,6 +6,7 @@ describe('Route template', () => {
     const meta: PageMeta[] = [
       {
         name: 'foo',
+        chunkName: 'foo',
         specifier: 'Foo',
         path: '/foo',
         pathSegments: ['foo'],
@@ -13,6 +14,7 @@ describe('Route template', () => {
       },
       {
         name: 'bar',
+        chunkName: 'bar',
         specifier: 'Bar',
         path: '/bar',
         pathSegments: ['bar'],
@@ -27,6 +29,7 @@ describe('Route template', () => {
     const meta: PageMeta[] = [
       {
         name: 'foo',
+        chunkName: 'foo',
         specifier: 'Foo',
         path: '/foo',
         pathSegments: ['foo'],
@@ -34,6 +37,7 @@ describe('Route template', () => {
         children: [
           {
             name: 'bar',
+            chunkName: 'bar',
             specifier: 'FooBar',
             path: 'bar',
             pathSegments: ['foo', 'bar'],
@@ -41,6 +45,7 @@ describe('Route template', () => {
           },
           {
             name: 'baz',
+            chunkName: 'baz',
             specifier: 'FooBaz',
             path: 'baz',
             pathSegments: ['foo', 'baz'],
@@ -57,6 +62,7 @@ describe('Route template', () => {
     const meta: PageMeta[] = [
       {
         name: 'foo',
+        chunkName: 'foo',
         specifier: 'Foo',
         path: '/foo',
         pathSegments: ['foo'],
@@ -64,6 +70,7 @@ describe('Route template', () => {
       },
       {
         name: 'bar',
+        chunkName: 'bar',
         specifier: 'Bar',
         path: '/bar',
         pathSegments: ['bar'],
@@ -78,6 +85,7 @@ describe('Route template', () => {
     const meta: PageMeta[] = [
       {
         name: 'foo',
+        chunkName: 'foo',
         specifier: 'Foo',
         path: '/foo',
         pathSegments: ['foo'],
@@ -95,6 +103,7 @@ describe('Route template', () => {
     const meta: PageMeta[] = [
       {
         name: 'foo',
+        chunkName: 'foo',
         specifier: 'Foo',
         path: '/foo',
         pathSegments: ['foo'],
@@ -116,6 +125,7 @@ describe('Route template', () => {
     const meta: PageMeta[] = [
       {
         name: 'foo',
+        chunkName: 'foo',
         specifier: 'Foo',
         path: '/foo',
         pathSegments: ['foo'],
@@ -123,6 +133,7 @@ describe('Route template', () => {
       },
       {
         name: 'bar',
+        chunkName: 'bar',
         specifier: 'Bar',
         path: '/bar',
         pathSegments: ['bar'],
@@ -133,17 +144,34 @@ describe('Route template', () => {
     expect(createRoutes(meta, true, 'page-')).toMatchSnapshot()
   })
 
+  it('should pick chunkName as a webpack chunk name', () => {
+    const meta: PageMeta[] = [
+      {
+        name: 'users',
+        chunkName: 'users-index',
+        specifier: 'users_index',
+        path: '/users',
+        pathSegments: ['users'],
+        component: '@/pages/users/index.vue',
+      },
+    ]
+
+    expect(createRoutes(meta, true, 'page-')).toMatchSnapshot()
+  })
+
   it('should not include name if the route has a default child', () => {
     const meta: PageMeta[] = [
       {
         name: 'foo',
+        chunkName: 'foo',
         specifier: 'Foo',
         path: '/foo',
         pathSegments: ['foo'],
         component: '@/pages/foo.vue',
         children: [
           {
-            name: 'foo-index',
+            name: 'foo',
+            chunkName: 'foo-index',
             specifier: 'FooIndex',
             path: '',
             pathSegments: ['foo'],


### PR DESCRIPTION
BREAKING CHANGE: route name no longer includes index. e.g. `/users/index.vue` generates a route with the route name `users` instead of `users-index`.

fix #143 