### PR TITLE
feat: support lang="js" for route custom block

### DIFF
--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -16,6 +16,9 @@ function foo_bar() {
 function foo__id() {
   return import(/* webpackChunkName: \\"foo-id\\" */ '@/pages/foo/_id.vue')
 }
+function route_js() {
+  return import(/* webpackChunkName: \\"route-js\\" */ '@/pages/route-js.vue')
+}
 function route() {
   return import(/* webpackChunkName: \\"route\\" */ '@/pages/route.vue')
 }
@@ -57,6 +60,15 @@ export default [
         component: foo__id,
       },
     ],
+  },
+  {
+    name: 'Test lang=js',
+    path: '/route-js',
+    component: route_js,
+    meta: {
+      requiresAuth: false,
+      layout: 'default',
+    },
   },
   {
     name: 'Test',

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -58,6 +58,21 @@ Array [
 ]
 `;
 
+exports[`Route resolution resolve route custom block with \`lang="js"\` 1`] = `
+Array [
+  Object {
+    "chunkName": "route-js",
+    "component": "@/pages/route-js.vue",
+    "name": "route-js",
+    "path": "/route-js",
+    "pathSegments": Array [
+      "route-js",
+    ],
+    "specifier": "route_js",
+  },
+]
+`;
+
 exports[`Route resolution resolve route meta 1`] = `
 Array [
   Object {

--- a/test/fixtures/route-js.vue
+++ b/test/fixtures/route-js.vue
@@ -1,0 +1,9 @@
+<route lang="js">
+{
+  name: 'Test lang=js',
+  meta: {
+    requiresAuth: false,
+    layout: 'default'
+  }
+}
+</route>

--- a/test/resolve.spec.ts
+++ b/test/resolve.spec.ts
@@ -99,6 +99,8 @@ describe('Route resolution', () => {
 
   test('resolve route custom block', ['route.vue'])
 
+  test('resolve route custom block with `lang="js"`', ['route-js.vue'])
+
   test('resolves as nested routes', ['index.vue', 'foo.vue'], {
     nested: true,
   })


### PR DESCRIPTION
Add js-like syntax support for `route` custom block. It works with `lang="js"` attribute.
![image](https://user-images.githubusercontent.com/3998654/90335737-ba07dd00-dfdf-11ea-80f1-f335333c82a1.png)
