### PR TITLE
fix: ensure optional param under index directory

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -182,7 +182,6 @@ function toActualPath(segments: string[]): string[] {
   segments = segments.slice(0, -1).concat(last)
 
   return segments
-    .filter((s) => !isOmittable(s))
     .map((s, i) => {
       if (s[0] === '_') {
         const suffix = lastIndex === i ? '?' : ''
@@ -191,6 +190,7 @@ function toActualPath(segments: string[]): string[] {
         return s
       }
     })
+    .filter((s) => !isOmittable(s))
 }
 
 function pathToMapPath(segments: string[]): string[] {

--- a/test/__snapshots__/resolve.spec.ts.snap
+++ b/test/__snapshots__/resolve.spec.ts.snap
@@ -324,6 +324,21 @@ Array [
 ]
 `;
 
+exports[`Route resolution resolves optional dynamic route under index 1`] = `
+Array [
+  Object {
+    "chunkName": "index-param",
+    "component": "@/pages/index/_param.vue",
+    "name": "param",
+    "path": "/:param?",
+    "pathSegments": Array [
+      ":param?",
+    ],
+    "specifier": "index__param",
+  },
+]
+`;
+
 exports[`Route resolution resolves routes 1`] = `
 Array [
   Object {

--- a/test/resolve.spec.ts
+++ b/test/resolve.spec.ts
@@ -79,6 +79,8 @@ describe('Route resolution', () => {
 
   test('resolves dynamic routes with required param', ['users/_id/index.vue'])
 
+  test('resolves optional dynamic route under index', ['index/_param.vue'])
+
   test('resolves nested routes', ['foo.vue', 'foo/index.vue', 'foo/bar.vue'])
 
   test('resolves dynamic nested routes', [


### PR DESCRIPTION
Currently, dynamic routes under any omittable path (`index`) will not be optional param which is unexpected behavior or bug.

e.g.

```ts
- users
  |- _id.vue
  |- index
      |- _param.vue
```

generates:

```
/users/_id?
/users/_param // <- this should be optional
```

This PR fixes this bug and make all dynamic route optional if the param segment is defined as a file.