### PR TITLE
chore: put an underscore before a specifier even it does not start with a number

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -233,7 +233,7 @@ function pathToSpecifier(segments: string[]): string {
     .join('_')
     .replace(/[^a-zA-Z0-9]/g, '_')
 
-  return /^\d/.test(replaced) ? '_' + replaced : replaced
+  return '_' + replaced
 }
 
 function pathToRoute(


### PR DESCRIPTION
I'm facing a problem that `vue-auto-routing` fails to generate routes when I have a file named `new.vue`.

This happens because `new` is a reserved word in JS.
To avoid this, I think it's better to put an underscore before a specifier even it does not start with a number.

If the direction of this PR is okay, I'll also fix unit tests.

Thanks.